### PR TITLE
fix array30 module committing temporary input buffer when switching system IM

### DIFF
--- a/Modules/Array/LegacyModule/LegacyOVIMArray.cpp
+++ b/Modules/Array/LegacyModule/LegacyOVIMArray.cpp
@@ -48,6 +48,11 @@ void OVIMArrayContext::clear()
     changeState(STATE_WAIT_KEY1);
 }
 
+bool OVIMArrayContext::isComposing()
+{
+    return state == STATE_WAIT_CANDIDATE;
+}
+
 void OVIMArrayContext::updateDisplay(OVBuffer* buf)
 {
     buf->clear();
@@ -296,7 +301,7 @@ int OVIMArrayContext::keyEvent(OVKeyCode* key, OVBuffer* buf,
 	if (!keyseq.hasWildcardCharacter() && (keycode == '?' || keycode== '*')) {
 		murmur("candidate canceled because of wildcard");
 		clearCandidate(candi_bar);
-		state = STATE_WAIT_KEY3;
+		changeState(STATE_WAIT_KEY3);
 	}
 
     if( state == STATE_WAIT_CANDIDATE ){
@@ -396,7 +401,7 @@ void OVIMArrayContext::changeBackState(STATE s)
 void OVIMArrayContext::changeState(STATE s)
 {
     murmur("OVIMArray change state: %d -> %d", state, s);
-    state = s;  
+    state = s;
 }
 
 int OVIMArray::initialize(OVDictionary *conf, OVService* s, const char *path)

--- a/Modules/Array/LegacyModule/LegacyOVIMArray.h
+++ b/Modules/Array/LegacyModule/LegacyOVIMArray.h
@@ -80,6 +80,7 @@ public:
     }
     virtual int keyEvent(OVKeyCode* , OVBuffer* , OVCandidate* , OVService* );
     virtual void clear();
+    bool isComposing();
 private:
     void changeState(OV_Array::STATE s);
     void changeBackState(OV_Array::STATE s);

--- a/Modules/Array/OVIMArray.cpp
+++ b/Modules/Array/OVIMArray.cpp
@@ -75,7 +75,7 @@ OVEventHandlingContext* OpenVanilla::OVIMArray::createContext()
         m_legacyArrayModule->setForceSP(m_cfgForceSP);
     }
     
-    ::OVInputMethodContext* legacyContext = m_legacyArrayModule->newContext();
+    ::OVIMArrayContext* legacyContext = static_cast<::OVIMArrayContext*>(m_legacyArrayModule->newContext());
     OpenVanilla::OVIMArrayContext* context = new OpenVanilla::OVIMArrayContext(legacyContext);
     return context;
 }

--- a/Modules/Array/OVIMArrayContext.cpp
+++ b/Modules/Array/OVIMArrayContext.cpp
@@ -32,7 +32,7 @@
 
 using namespace OpenVanilla;
 
-OpenVanilla::OVIMArrayContext::OVIMArrayContext(::OVInputMethodContext* legacyContext)
+OpenVanilla::OVIMArrayContext::OVIMArrayContext(::OVIMArrayContext* legacyContext)
     : m_legacyContext(legacyContext)
 {
 }
@@ -49,12 +49,19 @@ void OpenVanilla::OVIMArrayContext::stopSession(OVLoaderService* loaderService)
 
 bool OpenVanilla::OVIMArrayContext::handleKey(OVKey* key, OVTextBuffer* readingText, OVTextBuffer* composingText, OVCandidateService* candidateService, OVLoaderService* loaderService)
 {
+    composingText->appendText(readingText->composedText());
     OVLegacyKeyCodeWrapper legacyKey(key);
     OVLegacyBufferWrapper legacyBuffer(composingText, candidateService);
     OVLegacyCandidateWrapper legacyCandidate(candidateService, loaderService);
     OVLegacyServiceWrapper legacyService(loaderService, composingText);
 
     int handled = m_legacyContext->keyEvent(&legacyKey, &legacyBuffer, &legacyCandidate, &legacyService);
+    if (m_legacyContext->isComposing()) {
+        readingText->clear();
+    } else {
+        readingText->setText(composingText->composedText());
+        composingText->setText(""); // use `setText` to keep its commit state
+    }
     return handled;
 }
 

--- a/Modules/Array/OVIMArrayContext.h
+++ b/Modules/Array/OVIMArrayContext.h
@@ -29,6 +29,7 @@
 #define OVIMArrayContext_h
 
 #include "OpenVanilla.h"
+#include "LegacyOVIMArray.h"
 
 class OVInputMethodContext;
 
@@ -39,14 +40,14 @@ namespace OpenVanilla {
     
     class OVIMArrayContext : public OVEventHandlingContext {
     public:
-        OVIMArrayContext(::OVInputMethodContext* legacyContext);
+        OVIMArrayContext(::OVIMArrayContext* legacyContext);
         virtual void startSession(OVLoaderService* loaderService);
         virtual void stopSession(OVLoaderService* loaderService);
         virtual bool handleKey(OVKey* key, OVTextBuffer* readingText, OVTextBuffer* composingText, OVCandidateService* candidateService, OVLoaderService* loaderService);
         virtual bool candidateSelected(OVCandidateService* candidateService, const string& text, size_t index, OVTextBuffer* readingText, OVTextBuffer* composingText, OVLoaderService* loaderService);
 
     protected:
-        ::OVInputMethodContext* m_legacyContext;
+        ::OVIMArrayContext* m_legacyContext;
     };
 };
 


### PR DESCRIPTION
Fixed a bug that Array module commits everything in its input buffer including temporary key sequences ("1↑", "4-1-", etc.) when switching to another system input method.

This is because Array module is a legacy module which uses `composingText` as its only buffer, while new modules use `composingText` and `readingText`. When switching to another system input method, OpenVanilla will commit current text in `composingText` but not `readingText`. It's necessary for Array input method to differentiate temporary input sequence and composed text.

So I added some code in Array module wrapper for moving text from `composingText` to `readingText` when the buffer is not composed for output.